### PR TITLE
Agrega un generador de Tag pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,19 @@ author: laplatarb
 # ...
 ```
 
+## Tags
+
+Los tags de un post permiten poder agrupar posts por cada tag.
+
+Los tags deben definirse como un arreglo de strings.
+
+En el post, usar la clave `tags`:
+```yaml
+---
+layout: post
+tags: [ruby, rails, "modular-monoliths"]
+```
+
 ## Writing posts
 
 1. Use not-prose when adding code snippets:

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,8 +6,9 @@
     </div>
 
     <div>
-      <nav class="flex flex-row justify-end gap-4 h-full my-auto font-md">
-        <a href="{{ site.github_url }}" class="text-gray-500 hover:text-gray-900 my-auto">Edit in Github</a>
+      <nav class="flex flex-row justify-end gap-6 h-full my-auto font-md">
+        <a href="{{ site.baseurl }}/tags" class="text-gray-500 hover:text-gray-900 my-auto">Tags</a>
+        <a href="{{ site.github_url }}" class="text-gray-500 hover:text-gray-900 my-auto">Editar en Github</a>
       </nav>
     </div>
   </header>

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -1,0 +1,14 @@
+---
+layout: default
+---
+
+{% assign posts = site.tags[page.tag] %}
+
+<div class="md:container md:mx-auto mx-6 mt-6">
+  <h1 class="text-5xl font-extrabold mb-10">#{{ page.tag }}</h1>
+  <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-12 md:gap-28">
+    {% for post in posts %}
+      {% include post_card.html post=post %}
+    {% endfor %}
+  </div>
+</div>

--- a/_plugins/tags.rb
+++ b/_plugins/tags.rb
@@ -1,0 +1,26 @@
+module Jekyll
+  class TagPageGenerator < Generator
+    safe true
+
+    def generate(site)
+      tags = site.posts.docs.flat_map { |post| post.data['tags'] || [] }.to_set
+      tags.each do |tag|
+        site.pages << TagPage.new(site, site.source, tag)
+      end
+    end
+  end
+
+  class TagPage < Page
+    def initialize(site, base, tag)
+      @site = site
+      @base = base
+      @dir  = File.join('tags', tag)
+      @name = 'index.html'
+
+      self.process(@name)
+      self.read_yaml(File.join(base, '_layouts'), 'tag.html')
+      self.data['tag'] = tag
+      self.data['title'] = "Tag: #{tag}"
+    end
+  end
+end

--- a/_posts/2023-06-01-ruby-meetup.markdown
+++ b/_posts/2023-06-01-ruby-meetup.markdown
@@ -3,7 +3,7 @@ layout: post
 title:  "Meetup de Junio, 2023"
 date:   2023-06-01 18:30:00 -0300
 categories: Meetup
-tags: Ruby Rails Meetup
+tags: [meetup, modular, feedback, testing]
 cover: "https://firebasestorage.googleapis.com/v0/b/la-plata-rb.appspot.com/o/meetup_01_06_2023%2Fbirra.jpg?alt=media"
 author: julian_pasquale
 ---

--- a/tags.markdown
+++ b/tags.markdown
@@ -1,0 +1,18 @@
+---
+layout: default
+title: Tags
+---
+
+<div class="md:container md:mx-auto mx-6 mt-6">
+  <h1 class="text-5xl font-extrabold mb-10">Tags</h1>
+  {% assign tags = site.tags | sort %}
+  <ul>
+    {% for tag in tags %}
+      <li>
+        <a href="/tags/{{ tag | first | slugify }}/" class="underline font-semibold">
+          #{{ tag[0] | replace:'-', ' ' }} ({{ tag | last | size }})
+        </a>
+      </li>
+    {% endfor %}
+  </ul>
+</div>


### PR DESCRIPTION
Resolves #14 

Las Tag pages agrupan los posts por tags.
Agrega un link en el header a la lista de todos los tags. Actualiza los tags de post de la meetup.
Agrega documentación sobre los tags.